### PR TITLE
added support for xpath selectors

### DIFF
--- a/HTTR/HTTR.csproj
+++ b/HTTR/HTTR.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/HTTR/HttrRequest.cs
+++ b/HTTR/HttrRequest.cs
@@ -8,16 +8,16 @@ namespace HTTR
 {
     public class HttrRequest
     {
-        public List<HttrTag> TagsToRetrive { get; set; }
+        public List<HttrSelector> Selectors { get; set; }
         public bool RetrieveAttributes { get; set; }
         public string XPath
         {
             get
             {
                 string result = "";
-                for (int i = 0; i < TagsToRetrive.Count; i++)
+                for (int i = 0; i < Selectors.Count; i++)
                 {
-                    result+=TagsToRetrive[i].XPath+" | ";
+                    result+= Selectors[i].XPath+" | ";
                 }
                 result = result.Remove(result.Length - 3);
                 return result;
@@ -28,10 +28,10 @@ namespace HTTR
         /// </summary>
         /// <param name="tagToRetrive">html tag you want to retrieve</param>
         /// <param name="retrieveAttributes">bool indicating if the outputed json will contain attributes</param>
-        public HttrRequest(HttrTag tagToRetrive, bool retrieveAttributes = true)
+        public HttrRequest(HttrSelector selector, bool retrieveAttributes = true)
         {
-            TagsToRetrive = new List<HttrTag>();
-            TagsToRetrive.Add(tagToRetrive);
+            Selectors = new List<HttrSelector>();
+            Selectors.Add(selector);
             RetrieveAttributes = retrieveAttributes;
         }
         /// <summary>
@@ -39,10 +39,10 @@ namespace HTTR
         /// </summary>
         /// <param name="tagsToRetrive">list of html tags you want to retrieve</param>
         /// <param name="retrieveAttributes">bool indicating if the outputed json will contain attributes</param>
-        public HttrRequest(List<HttrTag> tagsToRetrive, bool retrieveAttributes=true)
+        public HttrRequest(List<HttrSelector> selectors, bool retrieveAttributes=true)
         {
-            TagsToRetrive = new List<HttrTag>();
-            TagsToRetrive.AddRange(tagsToRetrive);
+            Selectors = new List<HttrSelector>();
+            Selectors.AddRange(selectors);
             RetrieveAttributes= retrieveAttributes;
         }
     }

--- a/HTTR/HttrSelector.cs
+++ b/HTTR/HttrSelector.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HTTR
+{
+    public abstract class HttrSelector
+    {
+        public abstract string XPath { get; }
+    }
+}

--- a/HTTR/HttrTag.cs
+++ b/HTTR/HttrTag.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace HTTR
 {
-    public class HttrTag
+    public class HttrTag:HttrSelector
     {
-        public string XPath 
+        public override string XPath 
         {
             get
             {

--- a/HTTR/HttrXPathSelector.cs
+++ b/HTTR/HttrXPathSelector.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HTTR
+{
+    public class HttrXPathSelector:HttrSelector
+    {
+        public override string XPath { get { return xpath; } }
+        private string xpath { get; set; }
+        public HttrXPathSelector(string Xpath)
+        {
+            xpath = Xpath;
+        }
+    }
+}


### PR DESCRIPTION
## Summarize your changes
Created abstarct class HttrSelector with abstract property XPath, created new class HttrXPathSelector which inherets from this class. Class HttrTag also inherets from this class, and HttrRequest now accepts HttrSelector class instead of HttrTag. Thanks to this you can use HttrXPathSelector for direct xpath queries and you can use HttrTag as before. 
## Issue ticket number and link
#7 
## Type of change
- [x] feature
- [ ] bug fix
- [ ] documentation
